### PR TITLE
Update ExtremeC_examples_chapter8_3_person.c

### DIFF
--- a/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_3_person.c
+++ b/ch08-inheritance-and-polymorphism/ExtremeC_examples_chapter8_3_person.c
@@ -28,7 +28,7 @@ void person_ctor(person_t* person,
 
 // Destructor
 void person_dtor(person_t* person) {
-  // Nothing to do
+  free(person);
 }
 
 // Behavior functions


### PR DESCRIPTION
Free the memory the person pointer is pointing at. Otherwise when student_dtor() calls person_dtor() the memory will not be released, resulting in a memory leak